### PR TITLE
Aesop format

### DIFF
--- a/app/config/exports.neon
+++ b/app/config/exports.neon
@@ -43,25 +43,37 @@ parameters:
                     idMask: '%%s.rocnik.%3$s' # sprintf mask: contestName, year, category
                 aesop.fol:
                     idMask: '%%s.FoL.%3$s' # sprintf mask: contestName, year, category
+                    eventTypeId: 9
                 aesop.dsef:
                     idMask: '%%s.dsef' # sprintf mask: contestName, year, category
+                    eventTypeId: 2
                 aesop.dsef2:
                     idMask: '%%s.dsef2' # sprintf mask: contestName, year, category
+                    eventTypeId: 14
                 aesop.tsaf:
                     idMask: '%%s.tsaf' # sprintf mask: contestName, year, category
+                    eventTypeId: 7
                 aesop.vaf:
                     idMask: '%%s.vaf' # sprintf mask: contestName, year, category
+                    eventTypeId: 3
                 aesop.sous.j:
                     idMask: '%%s.sous.jaro' # sprintf mask: contestName, year, category
+                    eventTypeId: 4
                 aesop.sous.p:
                     idMask: '%%s.sous.podzim' # sprintf mask: contestName, year, category
+                    eventTypeId: 5
                 aesop.klani.ct:
                     idMask: '%%s.fyziklani.%3$s' # sprintf mask: contestName, year, category
+                    eventTypeId: 1
                 aesop.klani.uc:
                     idMask: '%%s.fyziklani.ucitele' # sprintf mask: contestName, year, category
+                    eventTypeId: 1
                 aesop.tabor:
                     idMask: '%%s.tabor' # sprintf mask: contestName, year, category
+                    eventTypeId: 10
                 aesop.setkani.j:
                     idMask: '%%s.setkani.jaro' # sprintf mask: contestName, year, category
+                    eventTypeId: 11
                 aesop.setkani.p:
                     idMask: '%%s.setkani.podzim' # sprintf mask: contestName, year, category
+                    eventTypeId: 12

--- a/app/model/ORM/services/ServiceEvent.php
+++ b/app/model/ORM/services/ServiceEvent.php
@@ -16,6 +16,10 @@ class ServiceEvent extends AbstractServiceSingle {
                 ->where(DbNames::TAB_EVENT . '.year', $year);
         return $result;
     }
+    
+    public function getByEventTypeId(ModelContest $contest, $year, $eventTypeId) {
+        return $this->getEvents($contest, $year)->where(DbNames::TAB_EVENT . '.event_type_id', $eventTypeId)->fetch();
+    }
 
 }
 

--- a/data/exports/aesop.xsl
+++ b/data/exports/aesop.xsl
@@ -10,6 +10,9 @@
     <param name="errors-to"/>
     <param name="max-rank"/>
     <param name="max-points"/>
+    <param name="id-scope"/>
+    <param name="start-date"/>
+    <param name="end-date"/>
 
 
     <template match="/">
@@ -57,6 +60,18 @@
         <if test="$id-scope">
             <text>id-scope&#x9;</text>
             <value-of select="$id-scope"/>
+            <text>&#10;</text>
+        </if>
+        <!-- -->
+        <if test="$start-date">
+            <text>start-date&#x9;</text>
+            <value-of select="$start-date"/>
+            <text>&#10;</text>
+        </if>
+        <!-- -->
+        <if test="$end-date">
+            <text>end-date&#x9;</text>
+            <value-of select="$end-date"/>
             <text>&#10;</text>
         </if>
         <!-- -->

--- a/www/aesop/fykos.txt
+++ b/www/aesop/fykos.txt
@@ -96,3 +96,7 @@
 ../fykos29/q/aesop.sous.p?ha=1&format=aesop
 ../fykos30/q/aesop.sous.p?ha=1&format=aesop
 ../fykos30/q/aesop.dsef?ha=1&format=aesop
+../fykos30/q/aesop.fol?ha=1&format=aesop&p_category=A
+../fykos30/q/aesop.fol?ha=1&format=aesop&p_category=B
+../fykos30/q/aesop.fol?ha=1&format=aesop&p_category=C
+../fykos30/q/aesop.fol?ha=1&format=aesop&p_category=zahranicni


### PR DESCRIPTION
Comply with the AESOP import format specification. Now only 'max-rank' and 'max-points' in FoL and FoF export (hard to implement and missing data) and 'comment' (don't know what it means, probably unimportant) parameters are missing.