### PR TITLE
[fof] Synchronize column name with new schema

### DIFF
--- a/app/Components/Grids/Fyziklani/FyziklaniSubmitsGrid.php
+++ b/app/Components/Grids/Fyziklani/FyziklaniSubmitsGrid.php
@@ -47,7 +47,7 @@ class FyziklaniSubmitsGrid extends BaseGrid {
         $this->addColumn('label', _('Úloha'));
         $this->addColumn('points', _('Body'));
         $this->addColumn('room', _('Místnost'));
-        $this->addColumn('submitted_on', _('Zadané'));
+        $this->addColumn('modified', _('Zadané'));
         $this->addButton('edit', null)->setClass('btn btn-xs btn-default')->setLink(function ($row) use ($presenter) {
             return $presenter->link(':Fyziklani:Submit:edit', ['id' => $row->fyziklani_submit_id]);
         })->setText(_('Upravit'))->setShow(function ($row) use ($that) {

--- a/app/model/Fyziklani/CloseSubmitStrategy.php
+++ b/app/model/Fyziklani/CloseSubmitStrategy.php
@@ -122,7 +122,7 @@ class CloseSubmitStrategy {
             $arraySubmits[] = [
                 'task_id' => $submit->task_id,
                 'points' => $submit->points,
-                'time' => $submit->submitted_on
+                'time' => $submit->modified,
             ];
         }
         return ['data' => $arraySubmits, 'sum' => $sum, 'count' => $count];


### PR DESCRIPTION
Testy hlásí po mergi s masterem chybu, neboť se ještě někde používá starý název sloupce.

Toto se musí namergeovat před #80, aby testy passly.

Trochu se změnila sémantika, tak **je problém, co zobrazovat v tom gridu**, dal jsem tam `created`, ale asi by tam mělo být `updated`, pokud to je tedy vyplněno i při prvním uložení.

Ref: #62, #70 