### PR TITLE
[fof] Remove nonexistent .neon from bootstrap.php

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -43,9 +43,6 @@ $configurator->addConfig(CONFIG_DIR . '/config.local.neon', Configurator::NONE);
 foreach (Finder::findFiles('*.neon')->from(dirname(__FILE__) . '/../data/events') as $filename => $file) {
     $configurator->addConfig($filename, Configurator::NONE);
 }
-foreach (Finder::findFiles('*.neon')->from(dirname(__FILE__) . '/../data/fyziklani') as $filename => $file) {
-    $configurator->addConfig($filename, Configurator::NONE);
-}
 
 $container = $configurator->createContainer();
 


### PR DESCRIPTION
Fixup (discovered when I started it on second machine, unfortunately not covered with tests (they have own bootstrap.php).)