### PR TITLE
New person provider

### DIFF
--- a/app/Components/Forms/Controls/Autocomplete/ReactPersonProvider.php
+++ b/app/Components/Forms/Controls/Autocomplete/ReactPersonProvider.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace FKSDB\Components\Forms\Controls\Autocomplete;
+
+use ModelPerson;
+use Nette\Application\BadRequestException;
+use ServicePerson;
+
+/**
+ *
+ * @author Michal Červeňák <miso@fykos.cz>
+ */
+class ReactPersonProvider {
+
+    const NULL_VALUE = ['hasValue' => false];
+    const HAS_VALUE = ['hasValue' => true];
+
+    /**
+     * @var ServicePerson
+     */
+    private $servicePerson;
+
+
+    function __construct(ServicePerson $servicePerson) {
+        $this->servicePerson = $servicePerson;
+    }
+
+    /**
+     * @param $email
+     * @param $fields
+     * @param $acYear
+     * @return array
+     * @throws BadRequestException
+     */
+    public function getPersonByEmail($email, $fields, $acYear) {
+        $person = $this->servicePerson->findByEmail($email);
+        if (!$person) {
+            return $this->getDefaultData($email);
+        }
+        return $this->getParticipantData($person, $email, $fields, $acYear);
+    }
+
+    private function getDefaultData($email) {
+        return [
+            'email' => ['value' => $email, 'hasValue' => true,],
+            'person.personId' => ['value' => 0, 'hasValue' => true,],
+        ];
+    }
+
+    /**
+     * @param $person ModelPerson
+     * @param $email
+     * @param array $fields
+     * @param $acYear
+     * @return array
+     * @throws BadRequestException
+     */
+    private function getParticipantData(ModelPerson $person, $email, array $fields, $acYear) {
+
+        $fieldsData = $this->getDefaultData($email);
+
+        //$fields = ['personId', 'school', 'studyYear', 'idNumber', 'familyName', 'otherName'];
+        foreach ($fields as $field) {
+
+            /**
+             * @var $personHistory \ModelPersonHistory
+             */
+            $personHistory = $person->getHistory($acYear);
+            switch ($field) {
+                case 'person.personId':
+                    $fieldsData[$field] = ['value' => $person->person_id, 'hasValue' => true,];
+                    break;
+                case 'personHistory.schoolId':
+                    if ($personHistory) {
+                        $school = $personHistory->getSchool();
+                        $fieldsData[$field] = !!$school ? self::HAS_VALUE : self::NULL_VALUE;
+                    } else {
+                        $fieldsData[$field] = self::NULL_VALUE;
+                    }
+                    break;
+                case 'personHistory.studyYear':
+                    if ($personHistory) {
+                        $fieldsData[$field] = !!$personHistory->study_year ? self::HAS_VALUE : self::NULL_VALUE;
+                    } else {
+                        $fieldsData[$field] = self::NULL_VALUE;
+                    }
+                    break;
+                case 'personInfo.idNumber':
+                    $fieldsData[$field] = $person->getInfo()->id_number ? self::HAS_VALUE : self::NULL_VALUE;
+                    break;
+                case 'person.familyName':
+                    $fieldsData[$field] = ['value' => $person->family_name, 'hasValue' => true,];
+                    break;
+                case 'person.otherName':
+                    $fieldsData[$field] = ['value' => $person->other_name, 'hasValue' => true,];
+                    break;
+                default:
+                    //throw new BadRequestException('pole ' . $field . ' nexistuje');
+                    break;
+            }
+        }
+
+        return ['fields' => $fieldsData];
+    }
+
+}

--- a/www/js/TypeScriptSources/src/person-provider/actions/index.ts
+++ b/www/js/TypeScriptSources/src/person-provider/actions/index.ts
@@ -1,7 +1,8 @@
-export const ACTION_CLEAR_PROVIDER_PROPERTY = 'ACTION_CLEAR_PROVIDER_PROPERTY';
+export const ACTION_CLEAR_PROVIDER_PROPERTY = '@@person-provider/CLEAR_PROVIDER_PROPERTY';
 
-export const clearProviderProviderProperty = (selector: string) => {
+export const clearProviderProviderProperty = (selector: string, property: string) => {
     return {
+        property,
         selector,
         type: ACTION_CLEAR_PROVIDER_PROPERTY,
     };

--- a/www/js/TypeScriptSources/src/person-provider/actions/index.ts
+++ b/www/js/TypeScriptSources/src/person-provider/actions/index.ts
@@ -1,0 +1,8 @@
+export const ACTION_CLEAR_PROVIDER_PROPERTY = 'ACTION_CLEAR_PROVIDER_PROPERTY';
+
+export const clearProviderProviderProperty = (selector: string) => {
+    return {
+        selector,
+        type: ACTION_CLEAR_PROVIDER_PROPERTY,
+    };
+};

--- a/www/js/TypeScriptSources/src/person-provider/components/fields/person-history/school-id.tsx
+++ b/www/js/TypeScriptSources/src/person-provider/components/fields/person-history/school-id.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { Field } from 'redux-form';
+import { IPersonStringSelectror } from '../../../../brawl-registration/middleware/price';
+import Lang from '../../../../lang/components/lang';
+import SchoolProvider, { ISchoolProviderInputProps } from '../../../../school-provider/';
+import { required } from '../../../validation';
+import InputProvider from '../../input-provider';
+
+class Input extends InputProvider<ISchoolProviderInputProps> {
+}
+
+export default class SchoolId extends React.Component<IPersonStringSelectror, {}> {
+
+    public render() {
+        const {accessKey} = this.props;
+        return <Field
+            accessKey={accessKey}
+            JSXLabel={<Lang text={'School'}/>}
+            providerInput={SchoolProvider}
+            secure={true}
+            component={Input}
+            name={'personHistory.schoolId'}
+            validate={[required]}
+        />;
+    }
+}

--- a/www/js/TypeScriptSources/src/person-provider/components/fields/person-history/study-year.tsx
+++ b/www/js/TypeScriptSources/src/person-provider/components/fields/person-history/study-year.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { Field } from 'redux-form';
+import Select, { ISelectInputProps } from '../../../../brawl-registration/components/inputs/select';
+import { IPersonStringSelectror } from '../../../../brawl-registration/middleware/price';
+import { IStore } from '../../../../brawl-registration/reducers';
+import Lang from '../../../../lang/components/lang';
+import { required } from '../../../validation';
+import InputProvider from '../../input-provider';
+
+class Input extends InputProvider<ISelectInputProps> {
+}
+
+interface IState {
+    studyYearsDef?: any[];
+}
+
+class StudyYear extends React.Component<IPersonStringSelectror & IState, {}> {
+
+    public render() {
+        const {accessKey, studyYearsDef} = this.props;
+        const optGroups = [];
+        for (const name in studyYearsDef) {
+            if (studyYearsDef.hasOwnProperty(name)) {
+                const opts = [];
+                for (const value in studyYearsDef[name]) {
+                    if (studyYearsDef[name].hasOwnProperty(value)) {
+                        opts.push(<option key={value} value={value}>{studyYearsDef[name][value]}</option>);
+                    }
+                }
+                optGroups.push(<optgroup key={name} label={name}>
+                    {opts}
+                </optgroup>);
+            }
+        }
+        return <Field
+            accessKey={accessKey}
+            JSXLabel={<Lang text={'Study year'}/>}
+            secure={true}
+            component={Input}
+            providerInput={Select}
+            children={optGroups}
+            name={'personHistory.studyYear'}
+            validate={[required]}
+        />;
+    }
+}
+
+const mapDispatchToProps = (): IState => {
+    return {};
+};
+
+const mapStateToProps = (state: IStore): IState => {
+    return {
+        studyYearsDef: state.definitions.studyYears,
+    };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(StudyYear);

--- a/www/js/TypeScriptSources/src/person-provider/components/fields/person-info/id-number.tsx
+++ b/www/js/TypeScriptSources/src/person-provider/components/fields/person-info/id-number.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { Field } from 'redux-form';
+import BaseInput, { IBaseInputProps } from '../../../../brawl-registration/components/inputs/base-input';
+import { IPersonStringSelectror } from '../../../../brawl-registration/middleware/price';
+import Lang from '../../../../lang/components/lang';
+import { required } from '../../../validation';
+import InputProvider from '../../input-provider';
+
+class Input extends InputProvider<IBaseInputProps> {
+}
+
+export default class IdNumber extends React.Component<IPersonStringSelectror, {}> {
+
+    public render() {
+        const {accessKey} = this.props;
+        return <Field
+            accessKey={accessKey}
+            name={'personInfo.idNumber'}
+            component={Input}
+            JSXLabel={<Lang text={'Číslo OP/pasu'}/>}
+            inputType={'text'}
+            secure={true}
+            providerInput={BaseInput}
+            readOnly={false}
+            noChangeMode={false}
+            validate={[required]}
+        />;
+    }
+}

--- a/www/js/TypeScriptSources/src/person-provider/components/fields/person/family-name.tsx
+++ b/www/js/TypeScriptSources/src/person-provider/components/fields/person/family-name.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { Field } from 'redux-form';
+import BaseInput, { IBaseInputProps } from '../../../../brawl-registration/components/inputs/base-input';
+import { IPersonStringSelectror } from '../../../../brawl-registration/middleware/price';
+import Lang from '../../../../lang/components/lang';
+import { required } from '../../../validation';
+import InputProvider from '../../input-provider';
+
+class Input extends InputProvider<IBaseInputProps> {
+}
+
+export default class FamilyName extends React.Component<IPersonStringSelectror, {}> {
+    public render() {
+        const {accessKey} = this.props;
+        return <Field
+            accessKey={accessKey}
+            name={'person.familyName'}
+            JSXLabel={<Lang text={'Family name'}/>}
+            inputType={'text'}
+            component={Input}
+            providerInput={BaseInput}
+            placeholder={'Name'}
+            readOnly={false}
+            noChangeMode={true}
+            secure={false}
+            validate={[required]}
+        />;
+    }
+}

--- a/www/js/TypeScriptSources/src/person-provider/components/fields/person/other-name.tsx
+++ b/www/js/TypeScriptSources/src/person-provider/components/fields/person/other-name.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { Field } from 'redux-form';
+import BaseInput, { IBaseInputProps } from '../../../../brawl-registration/components/inputs/base-input';
+import { IPersonStringSelectror } from '../../../../brawl-registration/middleware/price';
+import Lang from '../../../../lang/components/lang';
+import { required } from '../../../validation';
+import InputProvider from '../../input-provider';
+
+class Input extends InputProvider<IBaseInputProps> {
+}
+
+export default class OtherName extends React.Component<IPersonStringSelectror, {}> {
+    public render() {
+        const {accessKey} = this.props;
+        return <Field
+            name={'person.otherName'}
+            accessKey={accessKey}
+            JSXLabel={<Lang text={'Other name'}/>}
+            inputType={'text'}
+            component={Input}
+            providerInput={BaseInput}
+            placeholder={'Name'}
+            readOnly={false}
+            secure={false}
+            noChangeMode={true}
+            validate={[required]}
+        />;
+    }
+}

--- a/www/js/TypeScriptSources/src/person-provider/components/form/button.tsx
+++ b/www/js/TypeScriptSources/src/person-provider/components/form/button.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { Dispatch } from 'redux';
+import { WrappedFieldProps } from 'redux-form';
+import { dispatchNetteFetch } from '../../../fetch-api/middleware/fetch';
+import Lang from '../../../lang/components/lang';
+import {
+    IRequestData,
+    IResponseData,
+    IStore,
+} from '../../interfaces';
+import {
+    isMail,
+    required,
+} from '../../validation';
+
+interface IProps {
+    accessKey: string;
+    value: string;
+}
+
+interface IState {
+    submitting?: boolean;
+    onFindButtonClick?: (value: string) => Promise<any>;
+}
+
+const findButtonClick = (dispatch: Dispatch<IStore>, value: string, accessKey: string) => {
+
+    return dispatchNetteFetch<IRequestData, IResponseData, IStore>('personProvider/' + accessKey, dispatch, {
+        act: 'person-provider',
+        data: {
+            accessKey,
+            email: value,
+            fields: [],
+        },
+    });
+};
+
+class Field extends React.Component<IProps & IState & WrappedFieldProps, {}> {
+    public render() {
+        const {submitting, onFindButtonClick} = this.props;
+
+        const valid = ![required, isMail].reduce((init, test) => {
+            return init || test(this.props.value);
+        }, '');
+        return <button className="btn btn-primary" disabled={submitting || !valid} onClick={(event) => {
+            event.preventDefault();
+            return onFindButtonClick(this.props.value);
+        }}>
+            <Lang text={'search'}/>
+        </button>;
+    }
+}
+
+const mapDispatchToProps = (dispatch: Dispatch<IStore>, ownProps: IProps): IState => {
+    return {
+        onFindButtonClick: (value) => findButtonClick(dispatch, value, ownProps.accessKey),
+    };
+};
+
+const mapStateToProps = (state: IStore, ownProps: IProps): IState => {
+    const key = 'personProvider/' + ownProps.accessKey;
+
+    if (state.submit.hasOwnProperty(key)) {
+        return {
+            submitting: state.submit[key].submitting,
+        };
+    }
+    return {};
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(Field);

--- a/www/js/TypeScriptSources/src/person-provider/components/form/field.tsx
+++ b/www/js/TypeScriptSources/src/person-provider/components/form/field.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { WrappedFieldProps } from 'redux-form';
+import Button from './button';
+import Input from './input';
+
+interface IProps {
+    accessKey: string;
+}
+
+export default class Field extends React.Component<IProps & WrappedFieldProps, {}> {
+    public render() {
+        const {input, meta, accessKey} = this.props;
+
+        return <>
+            <Input input={input} meta={meta}/>
+            <Button accessKey={accessKey} value={this.props.input.value} meta={meta} input={input}/>
+        </>;
+    }
+}

--- a/www/js/TypeScriptSources/src/person-provider/components/form/index.tsx
+++ b/www/js/TypeScriptSources/src/person-provider/components/form/index.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { Field } from 'redux-form';
+import {
+    isMail,
+    required,
+} from '../../validation';
+import InputField from './field';
+import HiddenField from '../../../brawl-registration/components/inputs/hidden';
+
+interface IProps {
+    accessKey: string;
+}
+
+export default class Form extends React.Component<IProps, {}> {
+
+    public render() {
+// validate={[required, isMail]}
+        return <div className={'form-group'}>
+            <Field
+                name={'email'}
+                component={InputField}
+                accessKey={this.props.accessKey}
+            />
+        </div>;
+    }
+
+}

--- a/www/js/TypeScriptSources/src/person-provider/components/form/input.tsx
+++ b/www/js/TypeScriptSources/src/person-provider/components/form/input.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { WrappedFieldProps } from 'redux-form';
+import Lang from '../../../lang/components/lang';
+
+export default class Input extends React.Component<WrappedFieldProps & {}, {}> {
+    public render() {
+        const {input, meta: {valid, touched}} = this.props;
+        return <>
+            <label><Lang text={'email'}/></label>
+            <input
+                {...input}
+                type="email"
+                required={true}
+                className={'form-control' + ((touched && valid) ? ' is-invalid' : '')}
+                placeholder="you-mail@example.com"
+            />
+        </>;
+    }
+}

--- a/www/js/TypeScriptSources/src/person-provider/components/index.tsx
+++ b/www/js/TypeScriptSources/src/person-provider/components/index.tsx
@@ -16,7 +16,7 @@ interface IProps {
 
 class App extends React.Component<IProps, {}> {
     public render() {
-        const store = config.dev ? createStore(app, applyMiddleware(logger)) : createStore(app);
+        const store = !config.dev ? createStore(app, applyMiddleware(logger)) : createStore(app);
         return (
             <Provider store={store}>
                 <PersonProvider accessKey={'person'}/>

--- a/www/js/TypeScriptSources/src/person-provider/components/index.tsx
+++ b/www/js/TypeScriptSources/src/person-provider/components/index.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+import {
+    applyMiddleware,
+    createStore,
+} from 'redux';
+import logger from 'redux-logger';
+import { config } from '../../config';
+import { app } from '../reducers';
+import PersonProvider from './provider';
+
+interface IProps {
+    definitions: any;
+}
+
+class App extends React.Component<IProps, {}> {
+    public render() {
+        const store = config.dev ? createStore(app, applyMiddleware(logger)) : createStore(app);
+        return (
+            <Provider store={store}>
+                <PersonProvider accessKey={'person'}/>
+            </Provider>
+        );
+    }
+}
+
+const el = document.getElementById('frmform-aggr-person_id');
+
+if (el) {
+
+    ReactDOM.render(<App definitions={{}}/>, el);
+}

--- a/www/js/TypeScriptSources/src/person-provider/components/input-provider/index.tsx
+++ b/www/js/TypeScriptSources/src/person-provider/components/input-provider/index.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { WrappedFieldProps } from 'redux-form';
+import Input from './input';
+import SecureDisplay from './secure-display';
+
+interface IProps<P = {}> extends IBaseInputProps {
+    secure: boolean;
+    providerInput: React.ComponentClass<WrappedFieldProps & P & IBaseInputProps>;
+    accessKey: string;
+}
+
+interface IBaseInputProps {
+    JSXLabel: JSX.Element;
+}
+
+export default class InputProvider<P= IBaseInputProps> extends React.Component<IProps<P> & P & WrappedFieldProps, {}> {
+
+    public render() {
+        const {
+            accessKey,
+            secure,
+            JSXLabel,
+            providerInput,
+            meta,
+            input,
+        } = this.props;
+
+        const child = React.createElement<any>(providerInput, this.props);
+        if (secure) {
+            return <>
+                <Input input={input} meta={meta} accessKey={accessKey}/>
+                <SecureDisplay accessKey={accessKey} input={input} meta={meta} JSXLabel={JSXLabel}>
+                    {child}
+                </SecureDisplay>
+            </>;
+        }
+
+        return <>
+            <Input input={input} meta={meta} accessKey={accessKey}/>
+            {child}
+        </>;
+    }
+}

--- a/www/js/TypeScriptSources/src/person-provider/components/input-provider/input.tsx
+++ b/www/js/TypeScriptSources/src/person-provider/components/input-provider/input.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { WrappedFieldProps } from 'redux-form';
+import {
+    IProviderValue,
+    IStore,
+} from '../../interfaces';
+
+interface IState {
+    providerProperty?: IProviderValue<any>;
+}
+
+interface IProps {
+    accessKey: string;
+}
+
+class Input extends React.Component<WrappedFieldProps & IProps & IState, {}> {
+
+    public componentDidMount() {
+        if (!this.props.providerProperty) {
+            return;
+        }
+        const {providerProperty: {hasValue, value}, input: {onChange}} = this.props;
+        if (hasValue) {
+            onChange(value ? value : true);
+        }
+    }
+
+    public render() {
+        return null;
+    }
+}
+
+const mapDispatchToProps = (): IState => {
+    return {};
+};
+
+const mapStateToProps = (state: IStore, ownProps: WrappedFieldProps & IProps): IState => {
+
+    const {accessKey, input: {name}} = ownProps;
+    if (state.provider.hasOwnProperty(accessKey)) {
+        return {
+            providerProperty: state.provider[accessKey].fields[name],
+        };
+    }
+    return {};
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(Input);

--- a/www/js/TypeScriptSources/src/person-provider/components/input-provider/secure-display.tsx
+++ b/www/js/TypeScriptSources/src/person-provider/components/input-provider/secure-display.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { Dispatch } from 'redux';
+import { WrappedFieldProps } from 'redux-form';
+import Lang from '../../../lang/components/lang';
+import { clearProviderProviderProperty } from '../../actions';
+import {
+    IProviderValue,
+    IStore,
+} from '../../interfaces';
+
+interface IProps {
+    accessKey: string;
+    JSXLabel: JSX.Element;
+}
+
+interface IState {
+    removeProviderValue?: () => void;
+    providerProperty?: IProviderValue<any>;
+}
+
+class SecureDisplay extends React.Component<WrappedFieldProps & IProps & IState, {}> {
+
+    public render() {
+        const {removeProviderValue, JSXLabel, providerProperty} = this.props;
+        if (providerProperty && providerProperty.hasValue) {
+            return <div className="form-group">
+                <label className="text-success">{JSXLabel}<span className="fa fa-check ml-1"/></label>
+                <small className="text-muted form-text">
+                    <Lang text={'Tento udaj už v systéme máme uložený, ak ho chcete zmeniť kliknite na tlačítko upraviť'}/>
+                </small>
+                <button className="btn btn-warning btn-sm" onClick={(event) => {
+                    event.preventDefault();
+                    removeProviderValue();
+                }}>
+                    <span className="fa fa-edit mr-1"/><Lang text={'Upraviť'}/>
+                </button>
+            </div>;
+        }
+        return <>{this.props.children}</>;
+    }
+}
+
+const mapDispatchToProps = (dispatch: Dispatch<IStore>, ownProps: WrappedFieldProps & IProps): IState => {
+    const {accessKey, input: {name}} = ownProps;
+    return {
+        removeProviderValue: () => dispatch(clearProviderProviderProperty(accessKey, name)),
+    };
+};
+
+const mapStateToProps = (state: IStore, ownProps: WrappedFieldProps & IProps): IState => {
+
+    const {accessKey, input: {name}} = ownProps;
+    if (state.provider.hasOwnProperty(accessKey)) {
+        return {
+            providerProperty: state.provider[accessKey].fields[name],
+        };
+    }
+    return {};
+};
+export default connect(mapStateToProps, mapDispatchToProps)(SecureDisplay);

--- a/www/js/TypeScriptSources/src/person-provider/components/input.tsx
+++ b/www/js/TypeScriptSources/src/person-provider/components/input.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { WrappedFieldProps } from 'redux-form';
+import { netteFetch } from '../../shared/helpers/fetch';
+import { IReceiveData } from '../../shared/interfaces';
+import {
+    IReceiveProviderData,
+    IResponseValues,
+} from '../interfaces';
+
+interface IProps {
+    onSubmitFail: (e) => void;
+    onSubmitStart: () => void;
+    onSubmitSuccess: (data: IReceiveData<IReceiveProviderData>) => void;
+}
+
+export default class Input extends React.Component<IProps & WrappedFieldProps, {}> {
+
+    public render() {
+        const {meta: {error, touched, valid, warning}, input, onSubmitSuccess, onSubmitFail, onSubmitStart} = this.props;
+        const onSearchButtonClick = (event) => {
+            event.preventDefault();
+            onSubmitStart();
+            netteFetch<IResponseValues, IReceiveData<IReceiveProviderData>>({
+                    act: 'person-provider',
+                    email: input.value,
+                    fields: [],
+                }, onSubmitSuccess
+                , onSubmitFail);
+        };
+        return <>
+            <div className={'form-group ' + (touched ? 'was-validated' : 'needs-validation')}>
+                <label>E-mail</label>
+                <input {...input} type="email" required={true} className="form-control" placeholder="yourmail@example.com"/>
+                {touched &&
+                ((error && <span className="invalid-feedback">{error}</span>) ||
+                    (warning && <span className="invalid-feedback">{warning}</span>))}
+            </div>
+            <button className="btn btn-primary" disabled={!valid} onClick={onSearchButtonClick}>Search</button>
+        </>;
+    }
+}

--- a/www/js/TypeScriptSources/src/person-provider/components/password.tsx
+++ b/www/js/TypeScriptSources/src/person-provider/components/password.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { WrappedFieldProps } from 'redux-form';
+import Lang from '../../lang/components/lang';
+
+interface IProps {
+    accessKey: string;
+}
+
+export default class Password extends React.Component<IProps & WrappedFieldProps, {}> {
+
+    public render() {
+        const {input, meta: {valid, touched}} = this.props;
+        return <>
+            <label><Lang text={'password'}/></label>
+            <input
+                {...input}
+                required={true}
+                className={'form-control' + ((touched && valid) ? ' is-invalid' : '')}
+                type="password"
+            />
+        </>;
+    }
+
+}

--- a/www/js/TypeScriptSources/src/person-provider/components/provider.tsx
+++ b/www/js/TypeScriptSources/src/person-provider/components/provider.tsx
@@ -1,79 +1,48 @@
 import * as React from 'react';
-import {
-    Field,
-} from 'redux-form';
-import Input from './input';
-
 import { connect } from 'react-redux';
-import { Dispatch } from 'redux';
-
 import {
-    submitFail,
-    submitStart,
-    submitSuccess,
-} from '../../shared/actions/submit';
-import { IReceiveData } from '../../shared/interfaces';
-import {
-    IReceiveProviderData,
     IStore,
 } from '../interfaces';
-import {
-    isMail,
-    required,
-} from '../validation';
+import Form from './form/';
 
 interface IProps {
     accessKey: string;
+    html?: string;
 }
 
 interface IState {
-    onSubmitFail?: (e) => void;
-    onSubmitStart?: () => void;
-    onSubmitSuccess?: (data: IReceiveData<IReceiveProviderData>) => void;
-    personId?: { hasValue: boolean; value: string };
+    isServed?: boolean;
 }
 
 class PersonProvider extends React.Component<IProps & IState, {}> {
 
     public render() {
-        if (this.props.personId) {
-            return <div>
-                {this.props.children}
-            </div>;
+        const {children} = this.props;
+
+        if (this.props.isServed) {
+            if (children) {
+                return <div>
+                    {children}
+                </div>;
+            } else {
+                return <div dangerouslySetInnerHTML={{__html: this.props.html}}/>;
+            }
+
         } else {
-            return <>
-                <Field name={'email'}
-                       component={Input}
-                       validate={[required, isMail]}
-                       onSubmitFail={(e) => {
-                           this.props.onSubmitFail(e);
-                       }}
-                       onSubmitStart={() => {
-                           this.props.onSubmitStart();
-                       }}
-                       onSubmitSuccess={(data) => {
-                           data.key = this.props.accessKey;
-                           this.props.onSubmitSuccess(data);
-                       }}
-                />
-            </>;
+            return <Form accessKey={this.props.accessKey}/>;
         }
     }
 }
 
-const mapDispatchToProps = (dispatch: Dispatch<IStore>): IState => {
-    return {
-        onSubmitFail: (e) => dispatch(submitFail(e)),
-        onSubmitStart: () => dispatch(submitStart()),
-        onSubmitSuccess: (data: IReceiveData<IReceiveProviderData>) => dispatch(submitSuccess<IReceiveData<IReceiveProviderData>>(data)),
-    };
+const mapDispatchToProps = (): IState => {
+    return {};
 };
 
 const mapStateToProps = (state: IStore, ownProps: IProps): IState => {
     const accessKey = ownProps.accessKey;
     if (state.provider.hasOwnProperty(accessKey)) {
         return {
-            personId: state.provider[accessKey].personId,
+            isServed: state.provider[accessKey].isServed,
         };
     }
     return {};

--- a/www/js/TypeScriptSources/src/person-provider/components/provider.tsx
+++ b/www/js/TypeScriptSources/src/person-provider/components/provider.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react';
+import {
+    Field,
+} from 'redux-form';
+import Input from './input';
+
+import { connect } from 'react-redux';
+import { Dispatch } from 'redux';
+
+import {
+    submitFail,
+    submitStart,
+    submitSuccess,
+} from '../../shared/actions/submit';
+import { IReceiveData } from '../../shared/interfaces';
+import {
+    IReceiveProviderData,
+    IStore,
+} from '../interfaces';
+import {
+    isMail,
+    required,
+} from '../validation';
+
+interface IProps {
+    accessKey: string;
+}
+
+interface IState {
+    onSubmitFail?: (e) => void;
+    onSubmitStart?: () => void;
+    onSubmitSuccess?: (data: IReceiveData<IReceiveProviderData>) => void;
+    personId?: { hasValue: boolean; value: string };
+}
+
+class PersonProvider extends React.Component<IProps & IState, {}> {
+
+    public render() {
+        if (this.props.personId) {
+            return <div>
+                {this.props.children}
+            </div>;
+        } else {
+            return <>
+                <Field name={'email'}
+                       component={Input}
+                       validate={[required, isMail]}
+                       onSubmitFail={(e) => {
+                           this.props.onSubmitFail(e);
+                       }}
+                       onSubmitStart={() => {
+                           this.props.onSubmitStart();
+                       }}
+                       onSubmitSuccess={(data) => {
+                           data.key = this.props.accessKey;
+                           this.props.onSubmitSuccess(data);
+                       }}
+                />
+            </>;
+        }
+    }
+}
+
+const mapDispatchToProps = (dispatch: Dispatch<IStore>): IState => {
+    return {
+        onSubmitFail: (e) => dispatch(submitFail(e)),
+        onSubmitStart: () => dispatch(submitStart()),
+        onSubmitSuccess: (data: IReceiveData<IReceiveProviderData>) => dispatch(submitSuccess<IReceiveData<IReceiveProviderData>>(data)),
+    };
+};
+
+const mapStateToProps = (state: IStore, ownProps: IProps): IState => {
+    const accessKey = ownProps.accessKey;
+    if (state.provider.hasOwnProperty(accessKey)) {
+        return {
+            personId: state.provider[accessKey].personId,
+        };
+    }
+    return {};
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(PersonProvider);

--- a/www/js/TypeScriptSources/src/person-provider/interfaces.ts
+++ b/www/js/TypeScriptSources/src/person-provider/interfaces.ts
@@ -1,22 +1,27 @@
-import { IState as ISubmitStore } from '../shared/reducers/submit';
+import { IState as ISubmitStore } from '../fetch-api/reducers/submit';
 import {
     IProviderStore,
-    IProviderValue,
 } from './reducers/provider';
-
-export interface IResponseValues {
-    act: string;
-    email: string;
-    fields: string[];
-}
 
 export interface IStore {
     submit: ISubmitStore;
     provider: IProviderStore;
 }
 
-export interface IReceiveProviderData {
+export interface IProviderValue<D = any> {
+    hasValue: boolean;
+    value: D;
+}
+
+export interface IResponseData {
+    key?: string;
     fields: {
-        [value: string]: IProviderValue;
+        [value: string]: IProviderValue<any>;
     };
+}
+
+export interface IRequestData {
+    accessKey: string;
+    email: string;
+    fields: string[];
 }

--- a/www/js/TypeScriptSources/src/person-provider/interfaces.ts
+++ b/www/js/TypeScriptSources/src/person-provider/interfaces.ts
@@ -1,0 +1,22 @@
+import { IState as ISubmitStore } from '../shared/reducers/submit';
+import {
+    IProviderStore,
+    IProviderValue,
+} from './reducers/provider';
+
+export interface IResponseValues {
+    act: string;
+    email: string;
+    fields: string[];
+}
+
+export interface IStore {
+    submit: ISubmitStore;
+    provider: IProviderStore;
+}
+
+export interface IReceiveProviderData {
+    fields: {
+        [value: string]: IProviderValue;
+    };
+}

--- a/www/js/TypeScriptSources/src/person-provider/reducers/index.ts
+++ b/www/js/TypeScriptSources/src/person-provider/reducers/index.ts
@@ -1,21 +1,8 @@
 import { combineReducers } from 'redux';
-
-import {
-    IState as ISubmitStore,
-    submit,
-} from '../../shared/reducers/submit';
-
-import {
-    IProviderStore,
-    provider,
-} from './provider';
+import { submit } from '../../fetch-api/reducers/submit';
+import { provider } from './provider';
 
 export const app = combineReducers({
     provider,
     submit,
 });
-
-export interface IStore {
-    submit: ISubmitStore;
-    provider: IProviderStore;
-}

--- a/www/js/TypeScriptSources/src/person-provider/reducers/index.ts
+++ b/www/js/TypeScriptSources/src/person-provider/reducers/index.ts
@@ -1,0 +1,21 @@
+import { combineReducers } from 'redux';
+
+import {
+    IState as ISubmitStore,
+    submit,
+} from '../../shared/reducers/submit';
+
+import {
+    IProviderStore,
+    provider,
+} from './provider';
+
+export const app = combineReducers({
+    provider,
+    submit,
+});
+
+export interface IStore {
+    submit: ISubmitStore;
+    provider: IProviderStore;
+}

--- a/www/js/TypeScriptSources/src/person-provider/reducers/provider.ts
+++ b/www/js/TypeScriptSources/src/person-provider/reducers/provider.ts
@@ -1,0 +1,51 @@
+import { ACTION_SUBMIT_SUCCESS } from '../../shared/actions/submit';
+import { ACTION_CLEAR_PROVIDER_PROPERTY } from '../actions';
+
+const providerLoadData = (state: IProviderStore, event): IProviderStore => {
+    // TODO catch only provider request
+    if (event.data.act !== 'person-provider') {
+        return state;
+    }
+    return {
+        ...state,
+        [event.data.key]: event.data.data.fields,
+    };
+
+};
+
+const clearProperty = (state: IProviderStore, action): IProviderStore => {
+    const [prefix, property] = action.selector.split('.');
+    return {
+        ...state,
+        [prefix]: {
+            ...state[prefix],
+            [property]: {
+                ...state[prefix][property],
+                hasValue: false,
+            },
+        },
+    };
+};
+
+export const provider = (state: IProviderStore = {}, event): IProviderStore => {
+    switch (event.type) {
+        case ACTION_SUBMIT_SUCCESS:
+            return providerLoadData(state, event);
+        case ACTION_CLEAR_PROVIDER_PROPERTY:
+            return clearProperty(state, event);
+        default:
+            return state;
+
+    }
+};
+
+export interface IProviderValue {
+    value: any;
+    hasValue: boolean;
+}
+
+export interface IProviderStore {
+    [accessKey: string]: {
+        [value: string]: IProviderValue;
+    };
+}

--- a/www/js/TypeScriptSources/src/person-provider/validation.ts
+++ b/www/js/TypeScriptSources/src/person-provider/validation.ts
@@ -4,3 +4,7 @@ export const isMail = (value: string): string => {
 export const required = (value): string => {
     return (value ? undefined : 'Required');
 };
+
+export const getAccessKey = (person: string, property: string): string => {
+    return person + '.' + property;
+};

--- a/www/js/TypeScriptSources/src/person-provider/validation.ts
+++ b/www/js/TypeScriptSources/src/person-provider/validation.ts
@@ -1,0 +1,6 @@
+export const isMail = (value: string): string => {
+    return /^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/.test(value) ? undefined : 'is not a valid Mail';
+};
+export const required = (value): string => {
+    return (value ? undefined : 'Required');
+};

--- a/www/js/TypeScriptSources/src/shared/actions/submit.ts
+++ b/www/js/TypeScriptSources/src/shared/actions/submit.ts
@@ -1,0 +1,24 @@
+export const ACTION_SUBMIT_SUCCESS = 'ACTION_SUBMIT_SUCCESS';
+
+export function submitSuccess<D>(data: D) {
+    return {
+        data,
+        type: ACTION_SUBMIT_SUCCESS,
+    };
+}
+
+export const ACTION_SUBMIT_FAIL = 'ACTION_SUBMIT_FAIL';
+export const submitFail = (error) => {
+    return {
+        error,
+        type: ACTION_SUBMIT_FAIL,
+    };
+};
+
+export const ACTION_SUBMIT_START = 'ACTION_SUBMIT_START';
+export const submitStart = () => {
+
+    return {
+        type: ACTION_SUBMIT_START,
+    };
+};

--- a/www/js/TypeScriptSources/src/shared/helpers/fetch.ts
+++ b/www/js/TypeScriptSources/src/shared/helpers/fetch.ts
@@ -1,6 +1,6 @@
-export async function netteFetch(data: any = null, success: (data: any) => void, error: (e) => void): Promise<any> {
+export async function netteFetch<F, D>(data: F = null, success: (data: D) => void, error: (e) => void): Promise<D> {
     const netteJQuery: any = $;
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve: (d: D) => void, reject) => {
         netteJQuery.nette.ajax({
             data,
             error: (e) => {
@@ -8,10 +8,32 @@ export async function netteFetch(data: any = null, success: (data: any) => void,
                 reject(e);
             },
             method: 'POST',
-            success: (d) => {
+            success: (d: D) => {
                 success(d);
                 resolve(d);
             },
+        });
+    });
+}
+
+export async function uploadFile<F, D>(data: F = null, success: (data: D) => void, error: (e: any) => void): Promise<D> {
+    return new Promise((resolve: (d: D) => void, reject) => {
+        $.ajax({
+            cache: false,
+            contentType: false,
+            data,
+            dataType: 'json',
+            error: (e) => {
+                reject(e);
+                error(e);
+            },
+            processData: false,
+            success: (d: D) => {
+                resolve(d);
+                success(d);
+            },
+            type: 'POST',
+            url: '#',
         });
     });
 }

--- a/www/js/TypeScriptSources/src/shared/interfaces.ts
+++ b/www/js/TypeScriptSources/src/shared/interfaces.ts
@@ -10,6 +10,7 @@ export interface ISubmit {
     teamId: number;
     created: any;
 }
+
 export interface ISubmits {
     [id: number]: ISubmit;
 }
@@ -36,4 +37,27 @@ export interface ITeam {
     y?: number;
     roomId?: number;
     room?: string;
+}
+
+export interface IUploadDataItem {
+    taskId: number;
+    deadline: string;
+    submitId: number;
+    name: string;
+    href: string;
+}
+
+export interface IUploadData {
+    [key: number]: IUploadDataItem;
+}
+
+export interface IMessage {
+    level: string;
+    text: string;
+}
+
+export interface IReceiveData<D> {
+    act: string;
+    messages: IMessage[];
+    data: D;
 }

--- a/www/js/TypeScriptSources/src/shared/reducers/submit.ts
+++ b/www/js/TypeScriptSources/src/shared/reducers/submit.ts
@@ -1,0 +1,57 @@
+import {
+    ACTION_SUBMIT_FAIL,
+    ACTION_SUBMIT_START,
+    ACTION_SUBMIT_SUCCESS,
+} from '../actions/submit';
+import {
+    IMessage,
+    IReceiveData,
+} from '../interfaces';
+
+export interface IState {
+    submitting?: boolean;
+    error?: any;
+    messages?: IMessage[];
+}
+
+const submitStart = (state: IState): IState => {
+    return {
+        ...state,
+        error: null,
+        messages: [],
+        submitting: true,
+    };
+};
+const submitFail = (state: IState, action): IState => {
+    return {
+        ...state,
+        error: action.error,
+        messages: [action.error.toString(), 'danger'],
+        submitting: false,
+    };
+};
+const submitSuccess = (state: IState, action): IState => {
+    const data: IReceiveData<any> = action.data;
+    return {
+        ...state,
+        messages: data.messages,
+        submitting: false,
+    };
+};
+
+const initState: IState = {
+    messages: [],
+};
+
+export const submit = (state: IState = initState, action): IState => {
+    switch (action.type) {
+        case ACTION_SUBMIT_START:
+            return submitStart(state);
+        case ACTION_SUBMIT_FAIL:
+            return submitFail(state, action);
+        case ACTION_SUBMIT_SUCCESS:
+            return submitSuccess(state, action);
+        default:
+            return state;
+    }
+};


### PR DESCRIPTION
@timkol:
Ak máš čas a náladu je tu úloha:
Vytvoril som nový person provider pre FOF, trocha som ho upravil aby mohol byť použitý aj iné prihlasovanie pre netteForm.

Je to to isté ako je napísané v jQuery ale u kúsok krajšie a prehľadnejšie.

Funkcia jednoduchá, pokiaľ nemá zadané personId tak renderuje formulár na mail, a inak renderuje to čo dostane (zatiaľ len JSX ale to mám pripravené aby to vedelo aj html). Pointov je teraz napísať back-end tak aby fungoval, v interfaces.ts som naznačil interface toho, čo posiela (fields sú zbytočné a nakoniec sa nebudú posielať) na server, naspäť posiela zatiaľ len nejaký objekt, kde je dané či (ne)našlo osobu (v pripade FOFu aj hodnoty, alebo či má/nemá hodnotu) a keď toto dostane tak vyrenderuje jsx/html, obsah toho čo dostane (u FOFu predom definovavý formulár v Reacte)

Otázkou, je pozrel by si na to a pokúsil by sa to napojiť? 