### PR TITLE
Jazyky pre client-side rendering

### DIFF
--- a/i18n/extract.sh
+++ b/i18n/extract.sh
@@ -4,6 +4,8 @@
 PHP_FILES="app libs"
 LATTE_FILES="app libs"
 NEON_FILES="app/config data/events"
+TSX_FILES="www/js/TypeScriptSources"
+
 
 # Output
 POT_FILE=i18n/messages.pot
@@ -18,6 +20,7 @@ LOCALE=i18n/locale
 
 LATTE_SUFFIX=latte2php
 NEON_SUFFIX=neon2php
+TSX_SUFFIX=tsx2php
 ROOT=`dirname ${BASH_SOURCE[0]}`/..
 
 function latte2php {
@@ -29,10 +32,14 @@ function neon2php {
 	sed "s/_(\(['\"].*\))[^)]*\$/<?php _(\1) ?>/" $1 | \
 	sed "s/_(\([^'\"].*\))[^)]*\$/<?php _('\1') ?>/" >$1.$NEON_SUFFIX
 }
+function tsx2php {
+    sed "s/<Lang\stext={\('.*'\)}\/>/\<\?php _(\1)\?\>/" $1 >$1.$TSX_SUFFIX
+}
 
 PHP_FILES=`echo "$PHP_FILES" | sed 's#^#'$ROOT'/#;s# # '$ROOT'/#g'`
 LATTE_FILES=`echo "$LATTE_FILES" | sed 's#^#'$ROOT'/#;s# # '$ROOT'/#g'`
 NEON_FILES=`echo "$NEON_FILES" | sed 's#^#'$ROOT'/#;s# # '$ROOT'/#g'`
+TSX_FILES=`echo "$TSX_FILES" | sed 's#^#'$ROOT'/#;s# # '$ROOT'/#g'`
 POT_FILE=$ROOT/$POT_FILE
 
 #
@@ -53,6 +60,14 @@ done
 
 find $NEON_FILES -iname "*.$NEON_SUFFIX" | xargs xgettext -L PHP --from-code=utf-8 -j -o $POT_FILE
 find $NEON_FILES -iname "*.$NEON_SUFFIX" | xargs rm
+
+for file in `find $TSX_FILES -iname "*.tsx"` ; do
+	tsx2php "$file"
+done
+
+find $TSX_FILES -iname "*.$TSX_SUFFIX" | xargs xgettext -L PHP --from-code=utf-8 -j -o $POT_FILE
+find $TSX_FILES -iname "*.$TSX_SUFFIX" | xargs rm
+
 
 #
 # Merge to PO files

--- a/www/js/TypeScriptSources/src/lang/actions/index.ts
+++ b/www/js/TypeScriptSources/src/lang/actions/index.ts
@@ -1,0 +1,7 @@
+export const ACTION_LOAD_LANG = 'ACTION_LOAD_LANG';
+export const loadLang = (data) => {
+    return {
+        data,
+        type: ACTION_LOAD_LANG,
+    };
+};

--- a/www/js/TypeScriptSources/src/lang/components/async.tsx
+++ b/www/js/TypeScriptSources/src/lang/components/async.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { Dispatch } from 'redux';
+import { dispatchNetteFetch } from '../../fetch-api/middleware/fetch';
+import { IRequest } from '../../fetch-api/middleware/interfaces';
+import { AJAX_CALL_ACTION } from '../constants';
+import { ILanguageResponseData } from '../interfaces';
+import { ILangStore } from '../reducers';
+
+interface IState {
+    onLoad?: (data: IRequest<{}>, success: (d) => void, error: (e) => void) => void;
+}
+
+class Async extends React.Component<IState, {}> {
+
+    public componentDidMount() {
+        const {onLoad} = this.props;
+        onLoad({act: AJAX_CALL_ACTION, data: {}}, () => null, () => null);
+    }
+
+    public render() {
+        return null;
+    }
+}
+
+const mapDispatchToProps = (dispatch: Dispatch<ILangStore>): IState => {
+    return {
+        onLoad: (data: IRequest<{}>, success, error) =>
+            dispatchNetteFetch<{}, ILanguageResponseData, ILangStore>
+            (AJAX_CALL_ACTION, dispatch, data, success, error),
+    };
+};
+
+const mapStateToProps = (): IState => {
+    return {};
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(Async);

--- a/www/js/TypeScriptSources/src/lang/components/lang.tsx
+++ b/www/js/TypeScriptSources/src/lang/components/lang.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { ILangStore } from '../reducers';
+
+interface IProps {
+    text: string;
+}
+
+interface IState {
+    isReady?: boolean;
+    translation?: string;
+}
+
+class LangDisplay extends React.Component<IState & IProps, {}> {
+
+    public render() {
+        const {isReady, translation, text} = this.props;
+        if (isReady) {
+            return <>{translation ? translation : text}</>;
+        }
+
+        return <span className="fa fa-spinner fa-spin"/>;
+    }
+
+}
+
+const mapDispatchToProps = (): IState => {
+    return {};
+};
+
+const mapStateToProps = (state: { lang: ILangStore }, ownProps: IProps): IState => {
+    if (!state.lang.data.hasOwnProperty(ownProps.text)) {
+      //  console.log(ownProps.text);
+    }
+    return {
+        isReady: state.lang.isReady,
+        translation: state.lang.data[ownProps.text],
+    };
+};
+
+const ConnectedDisplay = connect(mapStateToProps, mapDispatchToProps)(LangDisplay);
+
+export default class Lang extends React.Component<IProps, {}> {
+
+    public render() {
+        if (!this.props.text) {
+            return null;
+        }
+        return <ConnectedDisplay text={this.props.text}/>;
+    }
+
+}

--- a/www/js/TypeScriptSources/src/lang/components/sync.tsx
+++ b/www/js/TypeScriptSources/src/lang/components/sync.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { Dispatch } from 'redux';
+import { loadLang } from '../actions';
+import { ILanguageDefinition } from '../interfaces';
+import { ILangStore } from '../reducers';
+
+interface IState {
+    onLoad?: (data: ILanguageDefinition) => void;
+}
+
+interface IProps {
+    languagesDefinition: ILanguageDefinition;
+}
+
+class Async extends React.Component<IState & IProps, {}> {
+
+    public componentDidMount() {
+        const {onLoad, languagesDefinition} = this.props;
+        onLoad(languagesDefinition);
+    }
+
+    public render() {
+        return null;
+    }
+
+}
+
+const mapDispatchToProps = (dispatch: Dispatch<ILangStore>): IState => {
+    return {
+        onLoad: (data: ILanguageDefinition) => dispatch(loadLang(data)),
+    };
+};
+
+const mapStateToProps = (): IState => {
+    return {};
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(Async);

--- a/www/js/TypeScriptSources/src/lang/constants.ts
+++ b/www/js/TypeScriptSources/src/lang/constants.ts
@@ -1,0 +1,1 @@
+export const AJAX_CALL_ACTION = 'lang-downloader';

--- a/www/js/TypeScriptSources/src/lang/interfaces.ts
+++ b/www/js/TypeScriptSources/src/lang/interfaces.ts
@@ -1,0 +1,10 @@
+export interface ILanguageDefinition {
+    lang: string;
+    data: {
+        [key: string]: string;
+    };
+}
+
+export interface ILanguageResponseData {
+    [key: string]: string;
+}

--- a/www/js/TypeScriptSources/src/lang/reducers/index.ts
+++ b/www/js/TypeScriptSources/src/lang/reducers/index.ts
@@ -1,0 +1,37 @@
+import { ACTION_SUBMIT_SUCCESS } from '../../fetch-api/actions/submit';
+import { AJAX_CALL_ACTION } from '../constants';
+
+const loadData = (state: ILangStore, action): ILangStore => {
+    const {data} = action;
+    if (data.act !== AJAX_CALL_ACTION) {
+        return state;
+    }
+    return {
+        ...state,
+        data: {...data.data},
+        isReady: true,
+    };
+};
+
+const initialState = {
+    data: {},
+    isReady: false,
+    lang: 'cs',
+};
+
+export const lang = (state: ILangStore = initialState, event): ILangStore => {
+    switch (event.type) {
+        case ACTION_SUBMIT_SUCCESS:
+            return loadData(state, event);
+        default:
+            return state;
+    }
+};
+
+export interface ILangStore {
+    isReady: boolean;
+    lang: string;
+    data: {
+        [key: string]: string;
+    };
+}


### PR DESCRIPTION
Pokúsil som sa fixnuť sťahovanie jazykov a ich presun do JS.

v podstate chýba len back-end, kde treba zistiť, ktoré hodnoty sa budú posielať na klienta.
Spravil som zatiaľ len takúto provizornú metódu nieje gitovaná, kde sú vybrané kľúče, ktoré sa pošlú.
``
    private function handleLangDownload(\ReactResponse $response, array $requestData) {
        $keys = ['Other name', 'Team name', 'Family name',...]
        ];
        $data = [];
        foreach ($keys as $key) {
            $data[$key] = _($key);
        }
        $response->setAct('lang-downloader');
        $response->setData($data);
        $this->sendResponse($response);
    }
``