### PR TITLE
[mysql] default mysql time_zone to SYSTEM

### DIFF
--- a/libs/Nette/Database/Drivers/MySqlDriver.php
+++ b/libs/Nette/Database/Drivers/MySqlDriver.php
@@ -44,7 +44,6 @@ class MySqlDriver extends Nette\Object implements Nette\Database\ISupplementalDr
 		if (isset($options['sqlmode'])) {
 			$connection->query("SET sql_mode='$options[sqlmode]'");
 		}
-		$connection->query("SET time_zone='" . date('P') . "'");
 	}
 
 


### PR DESCRIPTION
UPOZORNĚNÍ: Jsem si celkem jistý, že je někde hack na obejití tohoto problému, oprava tedy může něco rozbít.

V současnosti to natvrdo nastaví "+01" když je zima a "+02" když je léto (viz date('P')). Pokud tedy v létě chceme uložit, či přečíst timestamp se zimní hodnotou (a naopak), dostaneme o hodinu špatný výsledek.

Tato změna způsobí, že time_zone bude na hodnotě 'SYSTEM'.

Alternativou je date('P') -> date('e'), musely by se pak ale naplnit timezone tabulky v mysql (defaultně není).

Tento PR je de facto backport z aktuální verze Nette, viz https://github.com/nette/nette/issues/1017.