### PR TITLE
ORDER BY statement in a FROM Subquery is Ignored

### DIFF
--- a/app/model/Exports/StoredQuery.php
+++ b/app/model/Exports/StoredQuery.php
@@ -246,7 +246,12 @@ class StoredQuery implements IDataSource, IResource {
     public function getData() {
         if ($this->data === null) {
             $innerSql = $this->getQueryPattern()->sql;
-            $sql = "SELECT * FROM ($innerSql LIMIT 18446744073709551615) " . self::INNER_QUERY; //LIMIT ... is only temporary bugfix to allow ORDER BY in inner SQL
+            if ($this->orders || $this->limit !== null || $this->offset !== null) {
+                $sql = "SELECT * FROM ($innerSql) " . self::INNER_QUERY;
+            }
+            else {
+                $sql = $innerSql;
+            }
 
             if ($this->orders) {
                 $sql .= ' ORDER BY ' . implode(', ', $this->orders);


### PR DESCRIPTION
Insert stored query into subquery only if non-default sort or limit is applied.

Solves #374 