### PR TITLE
Fix group by

### DIFF
--- a/app/model/Results/Models/BrojureResultsModel.php
+++ b/app/model/Results/Models/BrojureResultsModel.php
@@ -175,7 +175,7 @@ left join submit s ON s.task_id = t.task_id AND s.ct_id = ct.ct_id";
         $where = $this->conditionsToWhere($conditions);
         $query .= " where $where";
 
-        $query .= " group by p.person_id"; //abuse MySQL misimplementation of GROUP BY
+        $query .= " group by p.person_id, sch.name_abbrev "; //abuse MySQL misimplementation of GROUP BY
         $query .= " order by `" . self::ALIAS_SUM . "` DESC, p.family_name ASC, p.other_name ASC";
 
         $dataAlias = 'data';

--- a/app/model/Results/Models/CumulativeResultsModel.php
+++ b/app/model/Results/Models/CumulativeResultsModel.php
@@ -134,7 +134,7 @@ left join submit s ON s.task_id = t.task_id AND s.ct_id = ct.ct_id";
         $where = $this->conditionsToWhere($conditions);
         $query .= " where $where";
 
-        $query .= " group by p.person_id"; //abuse MySQL misimplementation of GROUP BY
+        $query .= " group by p.person_id, sch.name_abbrev "; //abuse MySQL misimplementation of GROUP BY
         $query .= " order by `" . self::ALIAS_SUM . "` DESC, p.family_name ASC, p.other_name ASC";
 
         $dataAlias = 'data';

--- a/app/model/Results/Models/DetailResultsModel.php
+++ b/app/model/Results/Models/DetailResultsModel.php
@@ -119,7 +119,7 @@ left join submit s ON s.task_id = t.task_id AND s.ct_id = ct.ct_id";
         $where = $this->conditionsToWhere($conditions);
         $query .= " where $where";
 
-        $query .= " group by p.person_id"; //abuse MySQL misimplementation of GROUP BY
+        $query .= " group by p.person_id, sch.name_abbrev "; //abuse MySQL misimplementation of GROUP BY
         $query .= " order by `" . self::ALIAS_SUM . "` DESC, p.family_name ASC, p.other_name ASC";
 
         $dataAlias = 'data';


### PR DESCRIPTION
Fix error on MySQL:
SQLSTATE[42000]: Syntax error or access violation: 1055 Expression #2 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'fksdb_test.sch.name_abbrev' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by