### PR TITLE
PersonFactory: open agreement in a new tab

### DIFF
--- a/app/Components/DatabaseReflection/Tables/PersonInfo/AgreedRow.php
+++ b/app/Components/DatabaseReflection/Tables/PersonInfo/AgreedRow.php
@@ -30,7 +30,8 @@ class AgreedRow extends AbstractRow {
         $control = new Checkbox($this->getTitle());
         $link = Html::el('a');
         $link->setText(_('Text souhlasu'));
-        $link->addAttributes(['href' => _('http://fykos.cz/doc/souhlas.pdf')]);
+        $link->addAttributes(['href' => _('http://fykos.cz/doc/souhlas.pdf'),
+                              'target' => '_blank']);
         $control->setOption('description', $link);
         return $control;
     }


### PR DESCRIPTION
Some browsers may not keep the state of the registration form and
opening in the same window then cleans all the data filled by the user.
To prevent this, open the document in a new tab explicitely.

UNTESTED