### PR TITLE
tests: Switch travis to use mariadb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,14 @@ addons:
   hosts:
   - db.fykos.local
   - auth.fykos.local
+  mariadb: '10.4'
 
 php:
   - 7.0
   - 7.1
 
-services:
-  - mysql
-
 before_install:
 #  - composer self-update
-  - echo $'\n[client]\nuser=root' >> ~/.my.cnf
 
 install:
 #  - composer install --no-interaction --prefer-source
@@ -22,6 +19,7 @@ install:
   - ./i18n/compile.sh
 
 before_script:
+  - sudo mysql -e "ALTER USER root@localhost IDENTIFIED VIA mysql_native_password; SET PASSWORD = PASSWORD('');"
   - ./tests/init-database.sh
   - ./tests/clear-database.sh
   - rm -rf temp/* tmp

--- a/app/model/ORM/abstract/AbstractServiceSingle.php
+++ b/app/model/ORM/abstract/AbstractServiceSingle.php
@@ -260,7 +260,8 @@ abstract class AbstractServiceSingle extends TableSelection implements IService 
         if ($this->defaults == null) {
             $this->defaults = [];
             foreach ($this->getColumnMetadata() as $column) {
-                if ($column['nativetype'] == 'TIMESTAMP' && isset($column['default']) && $column['default'] == 'CURRENT_TIMESTAMP') {
+                if ($column['nativetype'] == 'TIMESTAMP' && isset($column['default'])
+                    && !preg_match('/^[0-9]{4}/', $column['default'])) {
                     continue;
                 }
                 $this->defaults[$column['name']] = isset($column['default']) ? $column['default'] : null;


### PR DESCRIPTION
Do not merge (yet), it's a test test.

Since MariaDB is the engine we're using in production, distros are
switching to it and some exports may not be compatible with MySQL any
more, change the DB engine in tests too.