### PR TITLE
Drop references to global_session table

### DIFF
--- a/app/Models/ORM/DbNames.php
+++ b/app/Models/ORM/DbNames.php
@@ -17,7 +17,6 @@ class DbNames {
     public const TAB_EVENT_PARTICIPANT = 'event_participant';
     public const TAB_EVENT_TYPE = 'event_type';
     public const TAB_FLAG = 'flag';
-    public const TAB_GLOBAL_SESSION = 'global_session';
     public const TAB_GRANT = 'grant';
     public const TAB_LOGIN = 'login';
     public const TAB_ORG = 'org';

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -863,29 +863,6 @@ CREATE TABLE IF NOT EXISTS `stored_query_parameter` (
   ENGINE = InnoDB;
 
 -- -----------------------------------------------------
--- Table `global_session`
--- -----------------------------------------------------
-CREATE TABLE IF NOT EXISTS `global_session` (
-  `session_id` CHAR(32)    NOT NULL,
-  `login_id`   INT(11)     NOT NULL
-  COMMENT 'the only data\nfield of the session',
-  `since`      TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `until`      TIMESTAMP   NOT NULL DEFAULT '0000-00-00 00:00:00',
-  `remote_ip`  VARCHAR(45) NULL     DEFAULT NULL
-  COMMENT 'IP adresa klienta',
-  PRIMARY KEY (`session_id`),
-  INDEX `fk_auth_token_login1_idx` (`login_id` ASC),
-  CONSTRAINT `fk_auth_token_login10`
-  FOREIGN KEY (`login_id`)
-  REFERENCES `login` (`login_id`)
-    ON DELETE NO ACTION
-    ON UPDATE NO ACTION
-)
-  ENGINE = InnoDB
-  DEFAULT CHARACTER SET = utf8
-  COMMENT = 'Stores global sessions for SSO (single sign-on/off)';
-
--- -----------------------------------------------------
 -- Table `flag`
 -- -----------------------------------------------------
 CREATE TABLE IF NOT EXISTS `flag` (

--- a/tests/ModelsTests/DatabaseTestCase.php
+++ b/tests/ModelsTests/DatabaseTestCase.php
@@ -46,7 +46,6 @@ abstract class DatabaseTestCase extends TestCase {
     protected function tearDown(): void {
         $this->truncateTables([
             DbNames::TAB_ORG,
-            DbNames::TAB_GLOBAL_SESSION,
             DbNames::TAB_LOGIN,
             DbNames::TAB_PERSON_HISTORY,
             DbNames::TAB_CONTEST_YEAR,

--- a/tests/PresentersTests/PageDisplay/AbstractPageDisplayTestCase.php
+++ b/tests/PresentersTests/PageDisplay/AbstractPageDisplayTestCase.php
@@ -77,7 +77,7 @@ abstract class AbstractPageDisplayTestCase extends DatabaseTestCase {
     abstract public function getPages(): array;
 
     protected function tearDown(): void {
-        $this->truncateTables([DbNames::TAB_GLOBAL_SESSION, DbNames::TAB_GRANT, DbNames::TAB_LOGIN, DbNames::TAB_PERSON]);
+        $this->truncateTables([DbNames::TAB_GRANT, DbNames::TAB_LOGIN, DbNames::TAB_PERSON]);
         parent::tearDown();
     }
 }

--- a/tests/clear-database.sh
+++ b/tests/clear-database.sh
@@ -40,7 +40,6 @@ DELETE FROM contestant_base;
 DELETE FROM contest_year;
 DELETE FROM school;
 DELETE FROM address;
-DELETE FROM global_session;
 DELETE FROM auth_token;
 DELETE FROM login;
 DELETE FROM person;


### PR DESCRIPTION
This is unused after the merge of #1016.